### PR TITLE
Lab1.1 veracity/grupo1

### DIFF
--- a/labs/lab-1.1-veracity/connection_test.ipynb
+++ b/labs/lab-1.1-veracity/connection_test.ipynb
@@ -2,14 +2,24 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 33,
    "id": "570c430d",
    "metadata": {
     "vscode": {
      "languageId": "plaintext"
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Connection Successful! Your Biomedical Data Stack is ready.\n",
+      "   connection_status\n",
+      "0                  1\n"
+     ]
+    }
+   ],
    "source": [
     "import pandas as pd\n",
     "from sqlalchemy import create_engine\n",
@@ -28,29 +38,282 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 34,
    "id": "60bc7e14",
    "metadata": {
     "vscode": {
      "languageId": "plaintext"
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/tmp/ipykernel_116/111760011.py:1: UserWarning: pandas only supports SQLAlchemy connectable (engine/connection) or database string URI or sqlite3 DBAPI2 connection. Other DBAPI2 objects are not tested. Please consider using SQLAlchemy.\n",
+      "  pd.read_sql(\"\"\"\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>subject_id</th>\n",
+       "      <th>external_id</th>\n",
+       "      <th>full_name</th>\n",
+       "      <th>sex</th>\n",
+       "      <th>date_of_birth</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>1</td>\n",
+       "      <td>MRN-9001</td>\n",
+       "      <td>Paciente Sin Fecha</td>\n",
+       "      <td>F</td>\n",
+       "      <td>None</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>2</td>\n",
+       "      <td>MRN-9002</td>\n",
+       "      <td>None</td>\n",
+       "      <td>M</td>\n",
+       "      <td>1990-01-01</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>3</td>\n",
+       "      <td>MRN-9003</td>\n",
+       "      <td>Paciente Ciudad Typo</td>\n",
+       "      <td>M</td>\n",
+       "      <td>1985-09-10</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   subject_id external_id             full_name sex date_of_birth\n",
+       "0           1    MRN-9001    Paciente Sin Fecha   F          None\n",
+       "1           2    MRN-9002                  None   M    1990-01-01\n",
+       "2           3    MRN-9003  Paciente Ciudad Typo   M    1985-09-10"
+      ]
+     },
+     "execution_count": 34,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
-    "query = \"\"\"\n",
-    "-- escribe tu SQL aquí\n",
-    "\"\"\"\n",
-    "df = pd.read_sql(query, engine)\n",
-    "df"
+    "pd.read_sql(\"\"\"\n",
+    "SELECT\n",
+    "  subject_id,\n",
+    "  external_id,\n",
+    "  full_name,\n",
+    "  sex,\n",
+    "  date_of_birth\n",
+    "FROM patients\n",
+    "WHERE external_id LIKE 'MRN-9%'\n",
+    "ORDER BY external_id;\n",
+    "\"\"\", engine.raw_connection() )"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 48,
    "id": "a8ca31c4-fda5-4e71-a90d-a2639a28f397",
    "metadata": {},
-   "outputs": [],
-   "source": []
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>n_missing_dob</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   n_missing_dob\n",
+       "0              1"
+      ]
+     },
+     "execution_count": 48,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "query = \"\"\"\n",
+    "SELECT COUNT(*) AS n_missing_dob\n",
+    "FROM patients\n",
+    "WHERE full_name IS NULL;\n",
+    "\"\"\"\n",
+    "pd.read_sql(query, engine)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 47,
+   "id": "3c1d9001-2918-42e3-8773-2841c737447d",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>n_missing_dob</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   n_missing_dob\n",
+       "0              1"
+      ]
+     },
+     "execution_count": 47,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "query = \"\"\"\n",
+    "SELECT COUNT(*) AS n_missing_dob\n",
+    "FROM patients\n",
+    "WHERE date_of_birth IS NULL;\n",
+    "\"\"\"\n",
+    "pd.read_sql(query, engine)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 46,
+   "id": "e34f3f01-1ccc-4fa0-9bbf-6abce60edf12",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>diagnosis_id</th>\n",
+       "      <th>hadm_id</th>\n",
+       "      <th>diagnosis_text</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>Guateeeemala referral note</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   diagnosis_id  hadm_id              diagnosis_text\n",
+       "0             1        1  Guateeeemala referral note"
+      ]
+     },
+     "execution_count": 46,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "query = \"\"\"\n",
+    "SELECT *\n",
+    "FROM diagnoses\n",
+    "WHERE diagnosis_text LIKE '%%Guate%%';\n",
+    "\"\"\"\n",
+    "pd.read_sql(query, engine)\n"
+   ]
   }
  ],
  "metadata": {

--- a/labs/lab-1.1-veracity/sql/003_veracity_update.sql
+++ b/labs/lab-1.1-veracity/sql/003_veracity_update.sql
@@ -1,0 +1,30 @@
+-- Lab 1.1: Veracity / Missing Values
+-- Insertamos datos "reales": campos faltantes y errores de dedo.
+
+-- A) 3 pacientes "sucios" (missing + typo)
+INSERT INTO patients (external_id, full_name, sex, date_of_birth) VALUES
+('MRN-9001', 'Paciente Sin Fecha', 'F', NULL),            -- Missing DOB
+('MRN-9002', 'Paciente Sin Nombre', 'M', '1990-01-01'),   -- Nombre vacío (lo simulamos después)
+('MRN-9003', 'Paciente Ciudad Typo', 'M', '1985-09-10');  -- Ciudad con typo (simulada en admissions o diagnóstico)
+
+-- B) Si tu tabla patients no tiene "full_name" nullable o quieres simular missing:
+-- actualizamos a NULL un nombre (para simular realidad)
+UPDATE patients
+SET full_name = NULL
+WHERE external_id = 'MRN-9002';
+
+-- C) Simulamos un error de dedo en texto clínico (diagnosis)
+-- Creamos una admisión para MRN-9003 y le ponemos un texto con typo
+-- (Esto asume que subject_id de MRN-9003 existe. Si falla, revisa el Troubleshooting)
+INSERT INTO admissions (subject_id, admittime, dischtime, admission_type, hospital_expire_flag)
+SELECT subject_id, '2101-10-01 08:00', '2101-10-02 12:00', 'Emergency', false
+FROM patients
+WHERE external_id = 'MRN-9003';
+
+INSERT INTO diagnoses (hadm_id, diagnosis_text)
+SELECT a.hadm_id, 'Guateeeemala referral note'
+FROM admissions a
+JOIN patients p ON p.subject_id = a.subject_id
+WHERE p.external_id = 'MRN-9003'
+ORDER BY a.hadm_id DESC
+LIMIT 1;

--- a/labs/lab-1.1-veracity/sql/003_veracity_update.sql
+++ b/labs/lab-1.1-veracity/sql/003_veracity_update.sql
@@ -1,3 +1,47 @@
+-- Patients: identidad longitudinal
+CREATE TABLE IF NOT EXISTS patients (
+  subject_id SERIAL PRIMARY KEY,
+  external_id TEXT UNIQUE,
+  full_name TEXT,
+  sex CHAR(1) CHECK (sex IN ('M','F','O')),
+  date_of_birth DATE,
+  date_of_death DATE
+);
+
+-- Admissions: encuentros clínicos (eje del modelo)
+CREATE TABLE IF NOT EXISTS admissions (
+  hadm_id SERIAL PRIMARY KEY,
+  subject_id INT REFERENCES patients(subject_id),
+  admittime TIMESTAMP,
+  dischtime TIMESTAMP,
+  admission_type TEXT,
+  hospital_expire_flag BOOLEAN
+);
+
+-- Diagnoses: diagnósticos por admisión
+CREATE TABLE IF NOT EXISTS diagnoses (
+  diagnosis_id SERIAL PRIMARY KEY,
+  hadm_id INT REFERENCES admissions(hadm_id),
+  diagnosis_text TEXT
+);
+
+-- Lab dictionary
+CREATE TABLE IF NOT EXISTS d_labitems (
+  labitem_id SERIAL PRIMARY KEY,
+  label TEXT,
+  unit TEXT
+);
+
+-- Lab events
+CREATE TABLE IF NOT EXISTS labevents (
+  labevent_id SERIAL PRIMARY KEY,
+  hadm_id INT REFERENCES admissions(hadm_id),
+  labitem_id INT REFERENCES d_labitems(labitem_id),
+  charttime TIMESTAMP,
+  value_num NUMERIC
+);
+
+
 -- Lab 1.1: Veracity / Missing Values
 -- Insertamos datos "reales": campos faltantes y errores de dedo.
 


### PR DESCRIPTION
¿Por qué en datos reales hay campos NULL? (2 causas)
Al momento de llenar el dato no se preguntó o por error humano se omitió ingresarlo al sistema. Otra causa es que el dato no aplica o no existe para ese paciente. 

Si un hospital tiene 40% de date_of_birth faltante, ¿qué impacto tiene en un modelo de riesgo?
Si esto ocurre, se pierde la credibilidad de los datos. Esto porque la edad es importante al momento de analizar registros médicos, puesto que da información sobre mortalidad o complicaciones. Esto puede resultar en predicciones o resultados sesgados. 

Destruye la fiabilidad del modelo. La edad es casi siempre el predictor número 1 de riesgo médico (mortalidad, complicaciones). Si te falta casi la mitad de los datos, el modelo tendrá que "adivinar" (imputar) demasiado o descartar a casi la mitad de los pacientes, generando predicciones sesgadas e inútiles.

¿Qué es más peligroso: un NULL o un typo (“Guateeeemala”)? ¿por qué?
En cuestión de datos médicos, es más peligroso un typo debido a que se creerá que este es un nuevo dato y que no forma parte de la estructura que ya está creada, esto excluiría los datos del paciente dentro del grupo en el cual debería estar.