### PR TITLE
Lab1.1 veracity/grupo 8

### DIFF
--- a/labs/lab-1.1-veracity/connection_test.ipynb
+++ b/labs/lab-1.1-veracity/connection_test.ipynb
@@ -2,14 +2,24 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "id": "570c430d",
    "metadata": {
     "vscode": {
      "languageId": "plaintext"
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Connection Successful! Your Biomedical Data Stack is ready.\n",
+      "   connection_status\n",
+      "0                  1\n"
+     ]
+    }
+   ],
    "source": [
     "import pandas as pd\n",
     "from sqlalchemy import create_engine\n",
@@ -28,29 +38,294 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "60bc7e14",
-   "metadata": {
-    "vscode": {
-     "languageId": "plaintext"
+   "execution_count": 6,
+   "id": "a8ca31c4-fda5-4e71-a90d-a2639a28f397",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(1,)\n"
+     ]
     }
-   },
-   "outputs": [],
+   ],
    "source": [
-    "query = \"\"\"\n",
-    "-- escribe tu SQL aquí\n",
-    "\"\"\"\n",
-    "df = pd.read_sql(query, engine)\n",
-    "df"
+    "from sqlalchemy import text\n",
+    "\n",
+    "with engine.connect() as conn:\n",
+    "    result = conn.execute(text(\"SELECT 1;\"))\n",
+    "    print(result.fetchone())\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "a8ca31c4-fda5-4e71-a90d-a2639a28f397",
+   "execution_count": 16,
+   "id": "6f0956ab-0b2e-4760-84ed-baa2a055935b",
    "metadata": {},
-   "outputs": [],
-   "source": []
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>subject_id</th>\n",
+       "      <th>external_id</th>\n",
+       "      <th>full_name</th>\n",
+       "      <th>sex</th>\n",
+       "      <th>date_of_birth</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>1</td>\n",
+       "      <td>MRN-9001</td>\n",
+       "      <td>Paciente Sin Fecha</td>\n",
+       "      <td>F</td>\n",
+       "      <td>None</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>2</td>\n",
+       "      <td>MRN-9002</td>\n",
+       "      <td>None</td>\n",
+       "      <td>M</td>\n",
+       "      <td>1990-01-01</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>3</td>\n",
+       "      <td>MRN-9003</td>\n",
+       "      <td>Paciente Ciudad Typo</td>\n",
+       "      <td>M</td>\n",
+       "      <td>1985-09-10</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   subject_id external_id             full_name sex date_of_birth\n",
+       "0           1    MRN-9001    Paciente Sin Fecha   F          None\n",
+       "1           2    MRN-9002                  None   M    1990-01-01\n",
+       "2           3    MRN-9003  Paciente Ciudad Typo   M    1985-09-10"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "pd.read_sql(\n",
+    "        text(\"\"\"\n",
+    "            SELECT subject_id, external_id, full_name, sex, date_of_birth\n",
+    "            FROM patients\n",
+    "            WHERE external_id LIKE 'MRN-9%'\n",
+    "            ORDER BY external_id;\n",
+    "        \"\"\"),\n",
+    "        engine\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "02ffdc45-b233-4097-b96c-555f20d9ef61",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>n_missing_dob</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   n_missing_dob\n",
+       "0              1"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "query = \"\"\"\n",
+    "SELECT COUNT(*) AS n_missing_dob\n",
+    "FROM patients\n",
+    "WHERE date_of_birth IS NULL;\n",
+    "\"\"\"\n",
+    "pd.read_sql(query, engine)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "e49e360b-462d-477d-a1a0-b4bd11c02ce9",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>n_missing_name</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   n_missing_name\n",
+       "0               1"
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "query = \"\"\"\n",
+    "SELECT COUNT(*) AS n_missing_name\n",
+    "FROM patients\n",
+    "WHERE full_name IS NULL;\n",
+    "\"\"\"\n",
+    "pd.read_sql(query, engine)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "id": "b11dce75-6be2-4748-b267-0b66679d4f20",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>n_typos_guate</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   n_typos_guate\n",
+       "0              1"
+      ]
+     },
+     "execution_count": 20,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from sqlalchemy import text\n",
+    "\n",
+    "with engine.connect() as conn:\n",
+    "    pd.read_sql(\n",
+    "        text(\"\"\"\n",
+    "        SELECT COUNT(*) AS n_typos_guate\n",
+    "        FROM diagnoses\n",
+    "        WHERE diagnosis_text LIKE '%Guate%';\n",
+    "        \"\"\"),\n",
+    "        conn\n",
+    "    )\n",
+    "    df = pd.read_sql(text(query), conn)\n",
+    "\n",
+    "df\n"
+   ]
   }
  ],
  "metadata": {

--- a/labs/lab-1.1-veracity/sql/003_veracity_update.sql
+++ b/labs/lab-1.1-veracity/sql/003_veracity_update.sql
@@ -1,0 +1,30 @@
+-- Lab 1.1: Veracity / Missing Values
+-- Insertamos datos "reales": campos faltantes y errores de dedo.
+
+-- A) 3 pacientes "sucios" (missing + typo)
+INSERT INTO patients (external_id, full_name, sex, date_of_birth) VALUES
+('MRN-9001', 'Paciente Sin Fecha', 'F', NULL),            -- Missing DOB
+('MRN-9002', 'Paciente Sin Nombre', 'M', '1990-01-01'),   -- Nombre vacío (lo simulamos después)
+('MRN-9003', 'Paciente Ciudad Typo', 'M', '1985-09-10');  -- Ciudad con typo (simulada en admissions o diagnóstico)
+
+-- B) Si tu tabla patients no tiene "full_name" nullable o quieres simular missing:
+-- actualizamos a NULL un nombre (para simular realidad)
+UPDATE patients
+SET full_name = NULL
+WHERE external_id = 'MRN-9002';
+
+-- C) Simulamos un error de dedo en texto clínico (diagnosis)
+-- Creamos una admisión para MRN-9003 y le ponemos un texto con typo
+-- (Esto asume que subject_id de MRN-9003 existe. Si falla, revisa el Troubleshooting)
+INSERT INTO admissions (subject_id, admittime, dischtime, admission_type, hospital_expire_flag)
+SELECT subject_id, '2101-10-01 08:00', '2101-10-02 12:00', 'Emergency', false
+FROM patients
+WHERE external_id = 'MRN-9003';
+
+INSERT INTO diagnoses (hadm_id, diagnosis_text)
+SELECT a.hadm_id, 'Guateeeemala referral note'
+FROM admissions a
+JOIN patients p ON p.subject_id = a.subject_id
+WHERE p.external_id = 'MRN-9003'
+ORDER BY a.hadm_id DESC
+LIMIT 1;


### PR DESCRIPTION
1. ¿Por qué en datos reales hay campos NULL? Da 2 causas.
- El dato no fue registrado porque el paciente fue ingresado al sistema de emergencia, o el paciente tiene problemas de memoria.
- El dato fue registrado pero se pudo haber perdido en algún traslado de información o con un archivo corrupto.

2. Si un hospital tiene 40% de date_of_birth faltante, ¿qué impacto tiene en un modelo de riesgo?
- La confiabilidad y cantidad de información que puede proveer la base de datos se pone en riesgo. Si falta la mayoría de datos de fecha de nacimiento es posible que los modelos analizados no tomen en cuenta factores importantes como la edad de los pacientes a la hora de contraer ciertas enfermedades, o la mortalidad asociada con la edad (algunos casos son más graves por vulnerabilidad).

3. ¿Qué es más peligroso: un NULL o un typo (“Guateeeemala”)? ¿por qué?
- Un typo puede llegar a ser más peligroso. Esto se debe a que los datos NULL son fáciles de identificar dentro de las bases de datos, y en base a esto tomar una decisión. Sin embargo; con un typo es posible que se pierda información que sí estaba almacenada pero se pierde por no estar estandarizada. Además, es mucho más difícil encontrar este tipo de datos porque no se sabe cuál fue el mal tecleo que se pudo haber realizado.